### PR TITLE
Add io.flush() in "while" loop in WorkerBase.

### DIFF
--- a/shells/start_quick_server.sh
+++ b/shells/start_quick_server.sh
@@ -215,8 +215,9 @@ if [ $ALL -eq 1 ]; then
     ps -ef | grep -i "start_workers.*sh" | grep -v "grep" > /dev/null
     if [ $? -ne 0 ]; then
         I=0
+        rm -f $CURRDIR/logs/jobworker.log
         while [ $I -lt $NUMOFWORKERS ]; do
-            $CURRDIR/bin/instrument/start_workers.sh > $CURRDIR/logs/jobworker.log &
+            $CURRDIR/bin/instrument/start_workers.sh >> $CURRDIR/logs/jobworker.log &
             I=$((I+1))
         done
     fi

--- a/shells/stop_quick_server.sh
+++ b/shells/stop_quick_server.sh
@@ -197,8 +197,9 @@ if [ $RELOAD -ne 0 ]; then
 
     # start job worker
     I=0
+    rm -f $CURRDIR/logs/jobworker.log
     while [ $I -lt $NUMOFWORKERS ]; do
-        $CURRDIR/bin/instrument/start_workers.sh > $CURRDIR/logs/jobworker.log &
+        $CURRDIR/bin/instrument/start_workers.sh >> $CURRDIR/logs/jobworker.log &
         I=$((I+1))
     done
 fi

--- a/src/server/base/WorkerBase.lua
+++ b/src/server/base/WorkerBase.lua
@@ -30,6 +30,7 @@ local json_encode = json.encode
 local tostring = tostring
 local os_date = os.date
 local os_time = os.time
+local io_flush = io.flush
 
 local _JOB_HASH = "_JOB_HASH"
 
@@ -97,6 +98,7 @@ function WorkerBase:runEventLoop()
 
         printf("finish job, jobId: %s, start_time: %s, end_time:%s, result: %s", tostring(data.id), os_date("%Y-%m-%d %H:%M:%S", data.start_time), os_date("%Y-%m-%d %H:%M:%S"), res)
 
+        io_flush()
 ::reserve_next_job::
     end
 


### PR DESCRIPTION
- Solve the logs of job worker can't be printed correctly.